### PR TITLE
Add FastMCP macOS control tools and tests

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,8 +1,13 @@
 # server.py
 # Entrypoint: server.py:mcp
 
-import base64, io, os, time
-from typing import Literal, Optional
+import base64
+import io
+import os
+import tempfile
+import time
+from contextlib import contextmanager
+from typing import Iterable, Literal, Optional
 from fastmcp import FastMCP
 
 # IMPORTANT: export a variable literally named `mcp`
@@ -17,84 +22,224 @@ def ping() -> str:
 def echo(message: str, tag: Optional[str] = None) -> dict:
     return {"message": message, "tag": tag or "none"}
 
-# --- helpers (lazy import vncdotool so module import never fails) ---
-def _get_env() -> tuple[str, int, str]:
-    host = os.getenv("MACOS_HOST", "").strip()
-    pwd = os.getenv("MACOS_PASSWORD", "").strip()
-    if not host or ":" not in host:
-        raise RuntimeError("MACOS_HOST must be 'host:port' (e.g. 6.tcp.ngrok.io:17645)")
-    if not pwd:
-        raise RuntimeError("MACOS_PASSWORD must be set")
-    h, p = host.rsplit(":", 1)
-    try:
-        port = int(p)
-    except ValueError as e:
-        raise RuntimeError("MACOS_HOST port must be an integer") from e
-    return h, port, pwd
+DEFAULT_VNC_PORT = 5900
+DEFAULT_TIMEOUT_SECONDS = 8.0
 
-def _connect(timeout: float = 8.0):
+
+def _resolve_host_port(raw_host: str, port_env: str) -> tuple[str, int]:
+    host = raw_host.strip()
+    port_candidate = port_env.strip()
+    inline_port: Optional[str] = None
+
+    if host.startswith("[") and "]" in host:
+        closing = host.index("]")
+        bracketed = host[: closing + 1]
+        remainder = host[closing + 1 :]
+        host = bracketed
+        if remainder.startswith(":"):
+            candidate = remainder[1:]
+            if candidate.isdigit():
+                inline_port = candidate
+    else:
+        if host.count(":") == 1:
+            maybe_host, maybe_port = host.rsplit(":", 1)
+            if maybe_port.isdigit():
+                host = maybe_host
+                inline_port = maybe_port
+        elif "::" in host and host.count("::") == 1:
+            maybe_host, maybe_port = host.split("::", 1)
+            if maybe_port.isdigit():
+                host = maybe_host
+                inline_port = maybe_port
+
+    port_str = inline_port or port_candidate or str(DEFAULT_VNC_PORT)
+
+    try:
+        port = int(port_str)
+    except ValueError as exc:
+        raise RuntimeError("MACOS_PORT must be an integer") from exc
+
+    return host, port
+
+
+def _get_env() -> tuple[str, int, str, Optional[str], float]:
+    host_env = os.getenv("MACOS_HOST", "").strip()
+    port_env = os.getenv("MACOS_PORT", "").strip()
+    username = os.getenv("MACOS_USERNAME", "").strip() or None
+    password = os.getenv("MACOS_PASSWORD", "").strip()
+    timeout_env = os.getenv("MACOS_VNC_TIMEOUT", "").strip()
+
+    if not host_env:
+        raise RuntimeError("MACOS_HOST must be set")
+    if not password:
+        raise RuntimeError("MACOS_PASSWORD must be set")
+
+    host, port = _resolve_host_port(host_env, port_env)
+
+    if timeout_env:
+        try:
+            timeout = float(timeout_env)
+        except ValueError as exc:
+            raise RuntimeError("MACOS_VNC_TIMEOUT must be numeric") from exc
+    else:
+        timeout = DEFAULT_TIMEOUT_SECONDS
+
+    return host, port, password, username, timeout
+
+
+def _connect(timeout: Optional[float] = None):
     # lazy import so module import never breaks startup
     from vncdotool import api
-    host, port, pwd = _get_env()
-    target = f"{host}::{port}"  # vncdotool 1.2.0 format (no port kwarg)
-    client = api.connect(target, password=pwd)
+
+    host, port, password, username, default_timeout = _get_env()
+    effective_timeout = timeout if timeout is not None else default_timeout
+    target = f"{host}::{port}"
+    client = api.connect(target, password=password, username=username, timeout=effective_timeout)
     t0 = time.time()
-    while not getattr(client, "connected", True) and time.time() - t0 < timeout:
+    while not getattr(client, "connected", True) and time.time() - t0 < effective_timeout:
         time.sleep(0.05)
     return client
+
+
+@contextmanager
+def _client(timeout: Optional[float] = None):
+    client = _connect(timeout=timeout)
+    try:
+        yield client
+    finally:
+        client.disconnect()
+
+
+def _button_to_number(button: str) -> int:
+    b = button.lower().strip()
+    if b in {"left", "l", "button1", "1"}:
+        return 1
+    if b in {"middle", "m", "button2", "2"}:
+        return 2
+    if b in {"right", "r", "button3", "3"}:
+        return 3
+    raise ValueError("button must be 'left'|'middle'|'right'")
+
+
+TEXT_SPECIAL_MAP = {
+    "\n": "return",
+    "\r": "return",
+    "\t": "tab",
+    "\b": "bsp",
+    " ": "space",
+}
+
+SPECIAL_KEY_MAP = {
+    "enter": "return",
+    "return": "return",
+    "backspace": "bsp",
+    "delete": "delete",
+    "del": "delete",
+    "tab": "tab",
+    "escape": "esc",
+    "esc": "esc",
+    "space": "space",
+    "spacebar": "space",
+    "home": "home",
+    "end": "end",
+    "page_up": "pgup",
+    "pageup": "pgup",
+    "page-down": "pgdn",
+    "page_down": "pgdn",
+    "pagedown": "pgdn",
+    "left": "left",
+    "up": "up",
+    "right": "right",
+    "down": "down",
+}
+
+MODIFIER_KEY_MAP = {
+    "ctrl": "ctrl",
+    "control": "ctrl",
+    "shift": "shift",
+    "alt": "alt",
+    "option": "alt",
+    "cmd": "super",
+    "command": "super",
+    "meta": "super",
+    "super": "super",
+}
+
+
+def _normalise_special_key(key: str) -> str:
+    normalized = key.strip().lower().replace(" ", "_")
+    if not normalized:
+        raise ValueError("special_key must be non-empty")
+    return SPECIAL_KEY_MAP.get(normalized, normalized)
+
+
+def _normalise_combo_part(part: str) -> str:
+    part = part.strip()
+    if not part:
+        raise ValueError("Empty key in combination")
+    lowered = part.lower().replace(" ", "_")
+    if lowered in MODIFIER_KEY_MAP:
+        return MODIFIER_KEY_MAP[lowered]
+    if lowered in SPECIAL_KEY_MAP:
+        return SPECIAL_KEY_MAP[lowered]
+    if len(lowered) == 1:
+        return part
+    if lowered.startswith("f") and lowered[1:].isdigit():
+        return lowered
+    return part
+
+
+def _type_text(client, text: str, delay: float) -> None:
+    for ch in text:
+        key = TEXT_SPECIAL_MAP.get(ch, ch)
+        client.keyPress(key)
+        if delay > 0:
+            time.sleep(delay)
+
+
+def _press_combination(client, keys: Iterable[str], delay: float) -> None:
+    pressed: list[str] = []
+    try:
+        for key in keys:
+            client.keyDown(key)
+            pressed.append(key)
+        if delay > 0:
+            time.sleep(delay)
+    finally:
+        for key in reversed(pressed):
+            client.keyUp(key)
 
 # --- macOS control tools ---
 @mcp.tool()
 def remote_macos_get_screen() -> dict:
-    """
-    Capture the screen; returns {"image_base64": "<PNG base64>"}.
-    """
-    client = _connect()
-    try:
-        tmp_path = "/tmp/capture.png"
-        client.captureScreen(tmp_path)  # works on vncdotool 1.2.0
-        from PIL import Image
-        with Image.open(tmp_path) as img:
-            buf = io.BytesIO()
-            img.save(buf, format="PNG")
-        b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-        return {"image_base64": b64}
-    finally:
-        client.disconnect()
+    """Capture the screen and return PNG data along with dimensions."""
+    with _client() as client:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            client.captureScreen(tmp_path)
+            from PIL import Image
 
-def _button_to_mask(button: str) -> int:
-    b = button.lower()
-    if b in ("left", "l"): return 1
-    if b in ("middle", "m"): return 2
-    if b in ("right", "r"): return 4
-    raise ValueError("button must be 'left'|'middle'|'right'")
+            with Image.open(tmp_path) as img:
+                width, height = img.size
+                buf = io.BytesIO()
+                img.save(buf, format="PNG")
+            encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+            return {"image_base64": encoded, "width": width, "height": height}
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
 
-@mcp.tool()
-def remote_macos_send_keys(text: str) -> dict:
-    if not text:
-        raise ValueError("text must be non-empty")
-    client = _connect()
-    try:
-        for ch in text:
-            if ch == " ":
-                client.keyPress("space")
-            elif ch == "\n":
-                client.keyPress("enter")
-            else:
-                client.keyPress(ch)
-            time.sleep(0.005)
-        return {"ok": True}
-    finally:
-        client.disconnect()
 
 @mcp.tool()
 def remote_macos_mouse_move(x: int, y: int) -> dict:
-    client = _connect()
-    try:
+    """Move the mouse cursor to an absolute position."""
+    with _client() as client:
         client.mouseMove(int(x), int(y))
-        return {"ok": True}
-    finally:
-        client.disconnect()
+    return {"ok": True, "x": int(x), "y": int(y)}
+
 
 @mcp.tool()
 def remote_macos_mouse_click(
@@ -103,53 +248,152 @@ def remote_macos_mouse_click(
     button: Literal["left", "middle", "right"] = "left",
     double: bool = False,
 ) -> dict:
-    client = _connect()
-    try:
+    """Click at the requested coordinate. Set ``double=True`` for a double-click."""
+    button_number = _button_to_number(button)
+    clicks = 2 if double else 1
+    with _client() as client:
         client.mouseMove(int(x), int(y))
-        mask = _button_to_mask(button)
-        if double:
-            for _ in range(2):
-                client.mousePress(mask)
+        for i in range(clicks):
+            client.mousePress(button_number)
+            if double and i == 0:
                 time.sleep(0.06)
-        else:
-            client.mousePress(mask)
-        return {"ok": True}
-    finally:
-        client.disconnect()
+    return {"ok": True, "x": int(x), "y": int(y), "button": button, "clicks": clicks}
+
 
 @mcp.tool()
-def remote_macos_mouse_drag_n_drop(x0: int, y0: int, x1: int, y1: int, ms: int = 400) -> dict:
-    client = _connect()
-    try:
+def remote_macos_mouse_double_click(
+    x: int,
+    y: int,
+    button: Literal["left", "middle", "right"] = "left",
+) -> dict:
+    """Double-click at the requested coordinate."""
+    return remote_macos_mouse_click.fn(x=x, y=y, button=button, double=True)
+
+
+@mcp.tool()
+def remote_macos_mouse_scroll(
+    direction: Literal["up", "down"] = "down",
+    amount: int = 1,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    delay_ms: int = 80,
+) -> dict:
+    """Scroll using PageUp/PageDown key events; optionally move before scrolling."""
+    if amount < 1:
+        raise ValueError("amount must be >= 1")
+    if delay_ms < 0:
+        raise ValueError("delay_ms must be >= 0")
+    key = "pgup" if direction == "up" else "pgdn"
+    delay = delay_ms / 1000.0
+    with _client() as client:
+        if x is not None and y is not None:
+            client.mouseMove(int(x), int(y))
+        for i in range(amount):
+            client.keyPress(key)
+            if delay > 0 and i < amount - 1:
+                time.sleep(delay)
+    return {"ok": True, "direction": direction, "amount": amount}
+
+
+@mcp.tool()
+def remote_macos_mouse_drag_n_drop(
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    ms: int = 400,
+    button: Literal["left", "middle", "right"] = "left",
+    steps: Optional[int] = None,
+) -> dict:
+    """Drag from (x0, y0) to (x1, y1) with a configurable duration."""
+    if ms < 0:
+        raise ValueError("ms must be non-negative")
+    button_number = _button_to_number(button)
+    total_steps = steps if steps is not None else max(8, int(ms / 16))
+    total_steps = max(2, total_steps)
+    delay = ms / max(total_steps, 1) / 1000.0 if ms else 0.0
+
+    with _client() as client:
         client.mouseMove(int(x0), int(y0))
-        client.mouseDown(1)
-        steps = max(8, int(ms / 16))
-        dx = (int(x1) - int(x0)) / steps
-        dy = (int(y1) - int(y0)) / steps
-        for i in range(steps):
-            client.mouseMove(int(x0 + dx * (i + 1)), int(y0 + dy * (i + 1)))
-            time.sleep(ms / steps / 1000.0)
-        client.mouseUp(1)
-        return {"ok": True}
-    finally:
-        client.disconnect()
+        client.mouseDown(button_number)
+        try:
+            dx = (int(x1) - int(x0)) / total_steps
+            dy = (int(y1) - int(y0)) / total_steps
+            for i in range(total_steps):
+                nx = int(x0 + dx * (i + 1))
+                ny = int(y0 + dy * (i + 1))
+                client.mouseMove(nx, ny)
+                if delay > 0:
+                    time.sleep(delay)
+        finally:
+            client.mouseUp(button_number)
+
+    return {
+        "ok": True,
+        "start": {"x": int(x0), "y": int(y0)},
+        "end": {"x": int(x1), "y": int(y1)},
+        "steps": total_steps,
+        "duration_ms": ms,
+        "button": button,
+    }
+
 
 @mcp.tool()
-def remote_macos_open_application(name: str) -> dict:
-    if not name:
+def remote_macos_send_keys(
+    text: Optional[str] = None,
+    special_key: Optional[str] = None,
+    key_combination: Optional[str] = None,
+    delay_ms: int = 10,
+) -> dict:
+    """Send text, a single special key, or a key combination to macOS."""
+    if not any([text, special_key, key_combination]):
+        raise ValueError("Provide text, special_key, or key_combination")
+    if delay_ms < 0:
+        raise ValueError("delay_ms must be >= 0")
+
+    delay = delay_ms / 1000.0
+    actions: list[dict[str, object]] = []
+
+    with _client() as client:
+        if text:
+            _type_text(client, text, delay)
+            actions.append({"type": "text", "characters": len(text)})
+
+        if special_key:
+            key_name = _normalise_special_key(special_key)
+            client.keyPress(key_name)
+            actions.append({"type": "special", "key": key_name})
+
+        if key_combination:
+            parts = [
+                _normalise_combo_part(part)
+                for part in key_combination.split("+")
+                if part.strip()
+            ]
+            if not parts:
+                raise ValueError("key_combination must contain at least one key")
+            _press_combination(client, parts, delay)
+            actions.append({"type": "combination", "keys": parts})
+
+    return {"ok": True, "actions": actions}
+
+
+@mcp.tool()
+def remote_macos_open_application(name: str, wait_ms: int = 400) -> dict:
+    """Open an application using Spotlight search."""
+    if not name or not name.strip():
         raise ValueError("name must be non-empty")
-    client = _connect()
-    try:
-        # Spotlight: Cmd+Space, type, Enter
+    if wait_ms < 0:
+        raise ValueError("wait_ms must be >= 0")
+
+    with _client() as client:
         client.keyDown("super")
         client.keyPress("space")
         client.keyUp("super")
         time.sleep(0.25)
-        for ch in name:
-            client.keyPress("space" if ch == " " else ch)
-            time.sleep(0.01)
-        time.sleep(0.2)
-        client.keyPress("enter")
-        return {"ok": True}
-    finally:
-        client.disconnect()
+        _type_text(client, name, 0.01)
+        if wait_ms:
+            time.sleep(wait_ms / 1000.0)
+        client.keyPress("return")
+
+    return {"ok": True, "application": name}

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1,0 +1,225 @@
+import base64
+
+import base64
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import server
+
+
+@pytest.fixture
+def set_env(monkeypatch):
+    def _set(host: str = "example.com", password: str = "secret", **extra: str) -> None:
+        monkeypatch.setenv("MACOS_HOST", host)
+        monkeypatch.setenv("MACOS_PASSWORD", password)
+        for key, value in extra.items():
+            monkeypatch.setenv(key, str(value))
+
+    return _set
+
+
+def make_fake_client() -> MagicMock:
+    fake = MagicMock()
+    fake.disconnect = MagicMock()
+    return fake
+
+
+def tool_fn(obj):
+    return getattr(obj, "fn", obj)
+
+
+def test_resolve_host_port_defaults():
+    host, port = server._resolve_host_port("localhost", "")
+    assert host == "localhost"
+    assert port == server.DEFAULT_VNC_PORT
+
+
+def test_resolve_host_port_with_port_in_host():
+    host, port = server._resolve_host_port("example.com:5901", "")
+    assert host == "example.com"
+    assert port == 5901
+
+
+def test_resolve_host_port_with_env_port():
+    host, port = server._resolve_host_port("example.com", "6001")
+    assert host == "example.com"
+    assert port == 6001
+
+
+def test_resolve_host_port_ipv6_brackets():
+    host, port = server._resolve_host_port("[2601::1]:5999", "")
+    assert host == "[2601::1]"
+    assert port == 5999
+
+
+def test_resolve_host_port_invalid_port():
+    with pytest.raises(RuntimeError):
+        server._resolve_host_port("example.com", "abc")
+
+
+def test_get_env_requires_host(monkeypatch):
+    monkeypatch.delenv("MACOS_HOST", raising=False)
+    monkeypatch.setenv("MACOS_PASSWORD", "secret")
+    with pytest.raises(RuntimeError):
+        server._get_env()
+
+
+def test_get_env_requires_password(monkeypatch):
+    monkeypatch.setenv("MACOS_HOST", "example.com")
+    monkeypatch.delenv("MACOS_PASSWORD", raising=False)
+    with pytest.raises(RuntimeError):
+        server._get_env()
+
+
+def test_get_env_full(monkeypatch, set_env):
+    set_env(host="example.com:5901", password="secret")
+    monkeypatch.setenv("MACOS_USERNAME", "tester")
+    monkeypatch.setenv("MACOS_VNC_TIMEOUT", "12.5")
+    host, port, password, username, timeout = server._get_env()
+    assert host == "example.com"
+    assert port == 5901
+    assert password == "secret"
+    assert username == "tester"
+    assert timeout == 12.5
+
+
+def test_button_to_number():
+    assert server._button_to_number("left") == 1
+    assert server._button_to_number("Right") == 3
+    with pytest.raises(ValueError):
+        server._button_to_number("invalid")
+
+
+def test_remote_mouse_click(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_mouse_click)(10, 20, button="right", double=True)
+    assert result["clicks"] == 2
+    fake.mouseMove.assert_called_with(10, 20)
+    assert fake.mousePress.call_count == 2
+    fake.mousePress.assert_called_with(3)
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_mouse_double_click(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_mouse_double_click)(5, 6, button="middle")
+    assert result["clicks"] == 2
+    assert fake.mousePress.call_count == 2
+    fake.mousePress.assert_called_with(2)
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_mouse_scroll(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_mouse_scroll)(direction="up", amount=2, x=7, y=8, delay_ms=0)
+    assert result == {"ok": True, "direction": "up", "amount": 2}
+    fake.mouseMove.assert_called_with(7, 8)
+    assert fake.keyPress.call_count == 2
+    fake.keyPress.assert_called_with("pgup")
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_mouse_scroll_amount_validation(monkeypatch, set_env):
+    set_env()
+    with pytest.raises(ValueError):
+        tool_fn(server.remote_macos_mouse_scroll)(amount=0)
+    with pytest.raises(ValueError):
+        tool_fn(server.remote_macos_mouse_scroll)(delay_ms=-1)
+
+
+def test_remote_mouse_drag(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    monkeypatch.setattr(server.time, "sleep", lambda *_: None)
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_mouse_drag_n_drop)(0, 0, 10, 10, ms=160, button="left", steps=4)
+    assert result["steps"] == 4
+    fake.mouseDown.assert_called_with(1)
+    fake.mouseUp.assert_called_with(1)
+    assert fake.mouseMove.call_count >= 5  # initial + steps
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_send_keys_validation(monkeypatch, set_env):
+    set_env()
+    with pytest.raises(ValueError):
+        tool_fn(server.remote_macos_send_keys)()
+
+
+def test_remote_send_keys_combo_validation(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    with patch.object(server, "_connect", return_value=fake):
+        with pytest.raises(ValueError):
+            tool_fn(server.remote_macos_send_keys)(key_combination="   ")
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_send_keys_actions(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    monkeypatch.setattr(server.time, "sleep", lambda *_: None)
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_send_keys)(
+            text="Hi",
+            special_key="enter",
+            key_combination="cmd+shift+3",
+            delay_ms=0,
+        )
+
+    assert result["ok"] is True
+    actions_types = {action["type"] for action in result["actions"]}
+    assert {"text", "special", "combination"} <= actions_types
+    fake.keyPress.assert_any_call("H")
+    fake.keyPress.assert_any_call("i")
+    fake.keyPress.assert_any_call("return")
+    fake.keyDown.assert_any_call("super")
+    fake.keyDown.assert_any_call("shift")
+    fake.keyDown.assert_any_call("3")
+    fake.keyUp.assert_any_call("3")
+    fake.keyUp.assert_any_call("super")
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_open_application(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+    monkeypatch.setattr(server.time, "sleep", lambda *_: None)
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_open_application)("Safari", wait_ms=0)
+
+    assert result == {"ok": True, "application": "Safari"}
+    fake.keyDown.assert_called_with("super")
+    fake.keyUp.assert_called_with("super")
+    fake.keyPress.assert_any_call("space")
+    fake.keyPress.assert_any_call("return")
+    fake.disconnect.assert_called_once()
+
+
+def test_remote_get_screen(monkeypatch, set_env):
+    set_env()
+    fake = make_fake_client()
+
+    def capture(path: str) -> None:
+        from PIL import Image
+
+        Image.new("RGB", (4, 5), color=(255, 0, 0)).save(path)
+
+    fake.captureScreen.side_effect = capture
+
+    with patch.object(server, "_connect", return_value=fake):
+        result = tool_fn(server.remote_macos_get_screen)()
+
+    assert result["width"] == 4
+    assert result["height"] == 5
+    assert isinstance(result["image_base64"], str)
+    assert base64.b64decode(result["image_base64"])  # decodes successfully
+    fake.disconnect.assert_called_once()
+


### PR DESCRIPTION
## Summary
- extend the FastMCP server with robust environment parsing and a reusable VNC client context
- expose macOS control tools for screen capture, cursor control, scrolling, key input, drag-and-drop, and app launch
- add pytest coverage for the new helpers and tools using mocked VNC clients

## Testing
- pytest tests/test_server_tools.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9b678f824832dbb2e7c81fb93ab86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added mouse double-click and scrolling (up/down) with optional coordinates and per-action delay.
  - Enhanced drag-and-drop with button selection and configurable step-based movement; returns start/end and duration.
  - Introduced flexible key input: text, special keys, and key combinations with delay control; returns structured actions.
  - Application launch now supports a configurable wait period and uses Spotlight typing.
  - Screen capture now returns image width/height along with the PNG.

- Improvements
  - More robust connection handling (IPv6, environment-based defaults, per-call timeouts) and richer button/key aliases.

- Bug Fixes
  - Clearer errors for invalid inputs (negative delays, non-numeric timeouts, etc.).

- Tests
  - Added comprehensive test coverage for connection, input, and capture workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->